### PR TITLE
Fixed RecursiveTable crash

### DIFF
--- a/RecursiveTable/RecursiveTable.js
+++ b/RecursiveTable/RecursiveTable.js
@@ -81,7 +81,8 @@ var RecursiveTable = RecursiveTable || (function() {
                     var ti=_.reduce(v.results.rolls,function(m2,v2){
                         if(_.has(v2,'table')){
                             m2.push(_.reduce(v2.results,function(m3,v3){
-                                m3.push(v3.tableItem.name);
+                              var contentForward = roll3.tableItem.name.replace(/(\[\[)\s+(.+?)\s+(\]\])/g, '$1$2$3');
+                                m3.push(contentForward);
                                 return m3;
                             },[]).join(', '));
                         }

--- a/RecursiveTable/RecursiveTable.js
+++ b/RecursiveTable/RecursiveTable.js
@@ -5,8 +5,8 @@
 var RecursiveTable = RecursiveTable || (function() {
     'use strict';
 
-    var version = '0.1.2',
-        lastUpdate = 1453302547,
+    var version = '0.1.3',
+        lastUpdate = 1472246717,
         schemaVersion = 0.1,
         maxParseDepth = 10,
 

--- a/RecursiveTable/script.json
+++ b/RecursiveTable/script.json
@@ -1,6 +1,6 @@
 {
   "name": "RecursiveTable",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "authors": "The Aaron",
   "roll20userid": "104025",


### PR DESCRIPTION
I discovered accidentally that, if you have extra spaces in the inline rolls in table entries (e.g. you have something like `[[ 1t[some-table] ]]` that there was a syntax error thrown by the API. I have no idea what causes the particular syntax error mentioned, but I got past it by removing the spaces in those expressions.

The error: `SyntaxError: Expected "[" or [ |\t] but "1" found. undefined`
