### PR TITLE
TokenMod - Added missing directional low light fields

### DIFF
--- a/TokenMod/TokenMod.js
+++ b/TokenMod/TokenMod.js
@@ -40,6 +40,7 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
             has_limit_field_of_vision: {type: 'boolean'},
             has_limit_field_of_night_vision: {type: 'boolean'},
             has_directional_bright_light: {type: 'boolean'},
+            has_directional_low_light: {type: 'boolean'},
             
 
             // bounded by screen size
@@ -57,10 +58,12 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
             limit_field_of_vision_center: {type: 'degrees'},
             limit_field_of_night_vision_center: {type: 'degrees'},
             directional_bright_light_center: {type: 'degrees'},
+            directional_low_light_center: {type: 'degrees'},
 
             limit_field_of_vision_total: {type: 'circleSegment'},
             limit_field_of_night_vision_total: {type: 'circleSegment'},
             directional_bright_light_total: {type: 'circleSegment'},
+            directional_low_light_total: {type: 'circleSegment'},
 
 
 
@@ -1745,6 +1748,7 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell("has_limit_field_of_vision"),
                             _h.cell("has_limit_field_of_night_vision"),
                             _h.cell("has_directional_bright_light"),
+                            _h.cell("has_directional_low_light"),
                             _h.cell("bright_vision"),
                             _h.cell("has_night_vision"),
                             _h.cell("night_vision"),
@@ -1880,7 +1884,8 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell('rotation'),
                             _h.cell("limit_field_of_vision_center"),
                             _h.cell("limit_field_of_night_vision_center"),
-                            _h.cell("directional_bright_light_center")
+                            _h.cell("directional_bright_light_center"),
+                            _h.cell("directional_low_light_center")
                         )
                     ),
                     _h.paragraph('Rotating a token by 180 degrees.'),
@@ -1901,7 +1906,8 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell('light_losangle'),
                             _h.cell("limit_field_of_vision_total"),
                             _h.cell("limit_field_of_night_vision_total"),
-                            _h.cell("directional_bright_light_total")
+                            _h.cell("directional_bright_light_total"),
+                            _h.cell("directional_low_light_total")
                         )
                     ),
                     _h.paragraph('Setting line of sight angle to 90 degrees.'),
@@ -3071,6 +3077,14 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                     delta=getRelativeChange(token.get(k),f[0]);
                     if(_.isNumber(delta)) {
                         mods[k]=(((delta%360)+360)%360);
+                        
+                    }
+                    break;
+                case 'directional_low_light_center':
+                    delta=getRelativeChange(token.get(k),f[0]);
+                    if(_.isNumber(delta)) {
+                        mods[k]=(((delta%360)+360)%360);
+                        
                     }
                     break;
 
@@ -3084,7 +3098,13 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                         mods[k] = Math.min(360,Math.max(0,delta));
                     }
                     break;
-
+                case 'directional_low_light_total':
+                    delta=getRelativeChange(token.get(k),f[0]);
+                    if(_.isNumber(delta)) {
+                        mods[k] = Math.min(360,Math.max(0,delta));
+                        
+                    }
+                    break;
                 case 'light_radius':
                 case 'light_dimradius':
                 case 'light_multiplier':
@@ -3528,7 +3548,5 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
         ObserveTokenChange: observeTokenChange
     };
 })();
-
-
 
 

--- a/TokenMod/TokenMod.js
+++ b/TokenMod/TokenMod.js
@@ -3077,14 +3077,13 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                     delta=getRelativeChange(token.get(k),f[0]);
                     if(_.isNumber(delta)) {
                         mods[k]=(((delta%360)+360)%360);
-                        
                     }
                     break;
+                    
                 case 'directional_low_light_center':
                     delta=getRelativeChange(token.get(k),f[0]);
                     if(_.isNumber(delta)) {
                         mods[k]=(((delta%360)+360)%360);
-                        
                     }
                     break;
 
@@ -3098,13 +3097,14 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                         mods[k] = Math.min(360,Math.max(0,delta));
                     }
                     break;
+                    
                 case 'directional_low_light_total':
                     delta=getRelativeChange(token.get(k),f[0]);
                     if(_.isNumber(delta)) {
                         mods[k] = Math.min(360,Math.max(0,delta));
-                        
                     }
                     break;
+                    
                 case 'light_radius':
                 case 'light_dimradius':
                 case 'light_multiplier':

--- a/TokenMod/TokenMod.js
+++ b/TokenMod/TokenMod.js
@@ -1748,7 +1748,7 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell("has_limit_field_of_vision"),
                             _h.cell("has_limit_field_of_night_vision"),
                             _h.cell("has_directional_bright_light"),
-                            _h.cell("has_directional_low_light"),
+                            //_h.cell("has_directional_low_light"), //TODO: add when the Roll20 app renders directional low light properties correctly
                             _h.cell("bright_vision"),
                             _h.cell("has_night_vision"),
                             _h.cell("night_vision"),
@@ -1884,8 +1884,8 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell('rotation'),
                             _h.cell("limit_field_of_vision_center"),
                             _h.cell("limit_field_of_night_vision_center"),
-                            _h.cell("directional_bright_light_center"),
-                            _h.cell("directional_low_light_center")
+                            _h.cell("directional_bright_light_center")//, //TODO: add when the Roll20 app renders directional low light properties correctly
+                            //_h.cell("directional_low_light_center") //TODO: add when the Roll20 app renders directional low light properties correctly
                         )
                     ),
                     _h.paragraph('Rotating a token by 180 degrees.'),
@@ -1906,8 +1906,8 @@ const TokenMod = (() => { // eslint-disable-line no-unused-vars
                             _h.cell('light_losangle'),
                             _h.cell("limit_field_of_vision_total"),
                             _h.cell("limit_field_of_night_vision_total"),
-                            _h.cell("directional_bright_light_total"),
-                            _h.cell("directional_low_light_total")
+                            _h.cell("directional_bright_light_total")//, //TODO: add when the Roll20 app renders directional low light properties correctly
+                            //_h.cell("directional_low_light_total") //TODO: add when the Roll20 app renders directional low light properties correctly
                         )
                     ),
                     _h.paragraph('Setting line of sight angle to 90 degrees.'),


### PR DESCRIPTION
This adds the following fields to TokenMod:
- **has_directional_low_light** (boolean) 
- **directional_low_light_center** (degrees)
- **directional_low_light_total** (circleSegment)

For whatever reason, changing these properties won't change how anything renders. Because of this, no changes are visible in the help message as it would likely confuse end users. There are commented out sections in the source that can be uncommitted to update the help message when the feature will work for the end user. These should be easy to find because they are tagged with `//TODO: add when the Roll20 app renders directional low light properties correctly`

fixes #28 