### PR TITLE
Add support for token bar values to be used in tie-breakers

### DIFF
--- a/GroupInitiative/GroupInitiative.js
+++ b/GroupInitiative/GroupInitiative.js
@@ -348,6 +348,13 @@ const GroupInitiative = (() => { // eslint-disable-line no-unused-vars
             },
             desc: 'Adds the accompanying attribute as a decimal (0.01)'
         },
+        'tie-breaker-token_bar': {
+            type: adjustments.TOKEN,
+            func: function(t, idx) {
+                return 0.01*(parseFloat(t.get(`bar${idx}_value`))||0);
+            },
+            desc: 'Apply the bonus from the numbered bar on the token as a decimal (0.01), Defaults to 0 in the absence of a number'
+        },
         'ceiling': {
             type: adjustments.STAT,
             func: function(v) {


### PR DESCRIPTION
Our DM usually runs games with full sheets for active characters/NPCs but just basic tokens for monsters/mobs.  We want the mobs to be able to easily specify initiative in a token bar, and be correctly rolled with the characters for tie-breaking.  

To accomplish this I added a 'tie-breaker-token_bar' option to a local copy of your script and it's worked very well for us.  I wanted to offer it up for merge back into your repo in case you/others are interested in similar functionality.  Our groups look something like this:

```
!group-init --add-group --bare initiative|current  --tie-breaker initiative|current
!group-init --add-group --token_bar 1  --tie-breaker-token_bar 1
```

Thanks again for the code & support.

Cheers,
Andy