### PR TITLE
Update TableExport.js to include additional escape characters for import

### DIFF
--- a/TableExport/TableExport.js
+++ b/TableExport/TableExport.js
@@ -12,7 +12,9 @@ var TableExport = TableExport || (function() {
             '['   : '<%%91%%>',
             ']'   : '<%%93%%>',
             '--' : '<%%-%%>',
-            ' --' : '[TABLEEXPORT:ESCAPE]'
+            ' --' : '[TABLEEXPORT:ESCAPE]',
+	    '<'   : '<%%60%%>',
+            '>'   : '<%%62%%>'
         },
     
     esRE = function (s) {


### PR DESCRIPTION
Added html escape codes for less than and greater than symbols:
<%%60%%> for <
<%%62%%> for >

This enables use of break symbols in table entries e.g.
<%%60%%>br<%%62%%>
after using ExportTables to import table entries is converted to: 
<br>

Related to forum discussion https://app.roll20.net/forum/post/10394868/tableexport-script-request-using-as-an-escape/?pageforid=10394915#post-10394915. '%NEWLINE%' does not work for table import.